### PR TITLE
Fix newline escaping in gemspec.

### DIFF
--- a/ksr-maybe.gemspec
+++ b/ksr-maybe.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.summary = 'A library providing the optional type \'Maybe\''
   s.authors = ['Ryan Closner', 'Corey Farwell']
   s.email = 'eng@kickstarter.com'
-  s.files = `git ls-files`.split('\n')
+  s.files = `git ls-files`.split("\n")
   s.homepage = 'http://github.com/kickstarter/ruby-maybe'
   s.license = 'Apache-2.0'
 


### PR DESCRIPTION
```
'a\nb'.split('\n') == ['a\nb']
'a\nb'.split("\n") == ['a', 'b']
```

https://stackoverflow.com/questions/16406381/ruby-split-n-not-splitting-on-new-line