### PR TITLE
Add some basic docs to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,47 @@
 This gem provides a `Maybe` type. The `Maybe` type either contains a value
 (represented as `Just`) or it is empty (represented as `Nothing`).
 
+# Installation
+
+Install the `ksr-maybe` gem, or add it to your Gemfile with bundler:
+
+```ruby
+# In your Gemfile
+gem 'ksr-maybe'
+```
+
+# Usage
+
+Maybe is useful for handling potentially null values:
+
+```ruby
+User = Struct.new(:email, :name)
+
+users = [
+  User.new("jane@doe.com", "Jane Doe"),
+  User.new("john@doe.com", "John Doe")
+]
+
+# When value is not null
+
+user = users.find { |user| user.email == "jane@doe.com" }
+
+Maybe.from_nullable(user)
+  .map { |user| user.name }
+  .get_or_else { "User not found" }
+
+#=> "Jane Doe"
+
+# When value is null
+
+user = users.find { |user| user.email == "not@present.com" }
+
+Maybe.from_nullable(user)
+  .map { |user| user.name }
+  .get_or_else { "User not found" }
+
+#=> "User not found"
+```
 
 ## Contracts
 


### PR DESCRIPTION
 # WHAT

Adds some basic usage documentation to the README. Would be great to publish docs to RubyDoc.info after we make this public.

# WHY

Addresses #3

# WHO

👋 @frewsxcv, @kyeah, @stephencelis 